### PR TITLE
Zigsim

### DIFF
--- a/src/main/scala/ee/hrzn/chryse/ChryseApp.scala
+++ b/src/main/scala/ee/hrzn/chryse/ChryseApp.scala
@@ -70,26 +70,26 @@ abstract class ChryseApp {
           ),
         )
 
-      case Some(conf.cxxsim) =>
+      case Some(conf.cxxrtl) =>
         println(conf.versionBanner)
         val platform =
-          if (conf.cxxsim.platformChoices.length > 1)
-            conf.cxxsim.platformChoices
-              .find(_.id == conf.cxxsim.platform.get())
+          if (conf.cxxrtl.platformChoices.length > 1)
+            conf.cxxrtl.platformChoices
+              .find(_.id == conf.cxxrtl.platform.get())
               .get
           else
-            conf.cxxsim.platformChoices(0)
-        tasks.CxxsimTask(
+            conf.cxxrtl.platformChoices(0)
+        tasks.CxxrtlTask(
           this,
           platform,
           cxxrtlOptions.get,
-          tasks.CxxsimTask.Options(
-            conf.cxxsim.debug(),
-            conf.cxxsim.optimize(),
-            conf.cxxsim.force(),
-            conf.cxxsim.compileOnly(),
-            conf.cxxsim.vcd.toOption,
-            conf.cxxsim.trailing.getOrElse(List.empty),
+          tasks.CxxrtlTask.Options(
+            conf.cxxrtl.debug(),
+            conf.cxxrtl.optimize(),
+            conf.cxxrtl.force(),
+            conf.cxxrtl.compileOnly(),
+            conf.cxxrtl.vcd.toOption,
+            conf.cxxrtl.trailing.getOrElse(List.empty),
           ),
         )
 

--- a/src/main/scala/ee/hrzn/chryse/ChryseScallopConf.scala
+++ b/src/main/scala/ee/hrzn/chryse/ChryseScallopConf.scala
@@ -90,8 +90,8 @@ private[chryse] class ChryseScallopConf(chryse: ChryseApp, args: Array[String])
   }
   addSubcommand(build)
 
-  object cxxsim extends Subcommand("cxxsim") {
-    banner("Run the C++ simulator tests.")
+  object cxxrtl extends Subcommand("cxxrtl") {
+    banner("Run the CXXRTL simulator tests.")
 
     val platformChoices = chryse.cxxrtlOptions.map(_.platforms).getOrElse(Seq())
 
@@ -128,16 +128,16 @@ private[chryse] class ChryseScallopConf(chryse: ChryseApp, args: Array[String])
     val vcd =
       opt[String](
         argName = "file",
-        descr = "Output a VCD file when running cxxsim (passes --vcd <file> to the executable)",
+        descr = "Output a VCD file when running simulation (passes --vcd <file> to the executable)",
       )
     val trailing = trailArg[List[String]](
       name = "<arg> ...",
-      descr = "Other arguments for the cxxsim executable",
+      descr = "Other arguments for the simulation executable",
       required = false,
     )
   }
   if (chryse.cxxrtlOptions.isDefined)
-    addSubcommand(cxxsim)
+    addSubcommand(cxxrtl)
 
   for { sc <- chryse.additionalSubcommands }
     addSubcommand(sc)

--- a/src/main/scala/ee/hrzn/chryse/tasks/CxxrtlTask.scala
+++ b/src/main/scala/ee/hrzn/chryse/tasks/CxxrtlTask.scala
@@ -31,8 +31,8 @@ import java.nio.file.Paths
 import scala.collection.mutable
 import scala.sys.process._
 
-private[chryse] object CxxsimTask extends BaseTask {
-  private val cxxsimDir = "cxxsim"
+private[chryse] object CxxrtlTask extends BaseTask {
+  private val simDir = "cxxrtl"
   private val baseCxxOpts = Seq("-std=c++17", "-g", "-pedantic", "-Wall",
     "-Wextra", "-Wno-zero-length-array", "-Wno-unused-parameter")
 
@@ -51,7 +51,7 @@ private[chryse] object CxxsimTask extends BaseTask {
       appOptions: CxxrtlOptions,
       runOptions: Options,
   ): Unit = {
-    println(s"Building cxxsim ${platform.id} ...")
+    println(s"Building ${platform.id} (cxxrtl) ...")
 
     Files.createDirectories(Paths.get(buildDir, platform.id))
     if (runOptions.force) {
@@ -105,8 +105,8 @@ private[chryse] object CxxsimTask extends BaseTask {
     )
     runCu(CmdStepSynthesise, yosysCu)
 
-    val ccs     = Seq(ccPath) ++ filesInDirWithExt(cxxsimDir, ".cc")
-    val headers = filesInDirWithExt(cxxsimDir, ".h").toSeq
+    val ccs     = Seq(ccPath) ++ filesInDirWithExt(simDir, ".cc")
+    val headers = filesInDirWithExt(simDir, ".h").toSeq
 
     val yosysDatDir = Seq("yosys-config", "--datdir").!!.trim()
     val cxxOpts     = new mutable.ArrayBuffer[String]
@@ -116,7 +116,7 @@ private[chryse] object CxxsimTask extends BaseTask {
     if (runOptions.optimize) cxxOpts.append("-O3")
 
     def buildPathForCc(cc: String) =
-      cc.replace(s"$cxxsimDir/", s"$buildDir/${platform.id}/")
+      cc.replace(s"$simDir/", s"$buildDir/${platform.id}/")
         .replace(".cc", ".o")
 
     def compileCmdForCc(cc: String, obj: String): Seq[String] = Seq(


### PR DESCRIPTION
* [x] Rename `cxxsim` to `cxxrtl` since we're not actually C++-specific, just CXXRTL specific.
* [ ] Add CxxrtlPlatform option to use Zig instead of system `c++`.
* [ ] Decide on level of opinionated-ness about what we supply to user `build.zig`.